### PR TITLE
Valgrindsetting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         make score
     - name: Leak test
       run: |
-        make leak
+        make -i leak
     - name: Code coverage using Codecov 
       run: bash <(curl -s https://codecov.io/bash) 
     - name: merge file to main


### PR DESCRIPTION
We will still get this error message

```
Built and deploy at  build/build/main.out
==2080== Memcheck, a memory error detector
==2080== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2080== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==2080== Command: build/main.out
==2080== 
==2080== 
==2080== HEAP SUMMARY:
==2080==     in use at exit: 0 bytes in 0 blocks
==2080==   total heap usage: 1 allocs, 1 frees, 4,096 bytes allocated
==2080== 
==2080== All heap blocks were freed -- no leaks are possible
==2080== 
==2080== For lists of detected and suppressed errors, rerun with: -s
==2080== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
assertion failed: Calling init too late
```

But still get *pass* in Github Action. All record is saved in Action log.