### PR TITLE
Find similar/malloc fix

### DIFF
--- a/src/FindSimilar.c
+++ b/src/FindSimilar.c
@@ -16,53 +16,30 @@ void kill_MEM(struct MEMORY* mem){
 }
 
 void Init_MEM_GroupAnalysis(TxtSmry** smrys, int n_mails){
-    TokenInfo* tkf = NULL;
     ULONG nmail = (ULONG)n_mails;
     //Location of hashes
-    init_MEM(&loc_mem, nmail * Q_MODULO* INIT_SPURIOUS_COUNT);
+    init_MEM(&token_hashmaps, nmail * Q_MODULO);
     //Occupied hash index
     init_MEM(&existTokens_mem, nmail*INIT_UNIQUE_TOKEN_SIZE);
-    init_TokenInfo_arr(&tkf, nmail*Q_MODULO);
-    init_TxtSmry_arr(smrys, nmail, tkf, Q_MODULO);
+    init_TxtSmry_arr(smrys, nmail, Q_MODULO);
 
 }
 
 void kill_MEM_GroupAnalysis(TxtSmry* smrys){
-    kill_MEM(&loc_mem);
+    kill_MEM(&token_hashmaps);
     kill_MEM(&existTokens_mem);
-    kill_TokenInfo_arr(smrys[0].token);
 }
 
 
-void init_TokenInfo(TokenInfo* tkf){
-    assert(loc_mem.top_unused+INIT_SPURIOUS_COUNT <= loc_mem.LEN);
-    tkf->occur = 0;
-    tkf->loc = &loc_mem.ARRAY[loc_mem.top_unused];
-    tkf->isRealloc = false;
-    loc_mem.top_unused+= INIT_SPURIOUS_COUNT;
-
-    assert(tkf->loc != NULL);
-}
-
-void init_TokenInfo_arr(TokenInfo** tkf, ULONG len){ 
-    *tkf = (TokenInfo*)malloc(len*sizeof(TokenInfo));
-    for(int i=0;i<len;i++){
-        init_TokenInfo(&(*tkf)[i]);
-    }
-}
-
-void kill_TokenInfo_arr(TokenInfo* tkf){
-    free(tkf);
-}
-
-void init_TxtSmry(TxtSmry* smry, TokenInfo* memToken, int* pin_memToken,int hashMapsize){
+void init_TxtSmry(TxtSmry* smry, int hashMapsize){
     //Check memory is enough
+    assert(token_hashmaps.top_unused+hashMapsize <= token_hashmaps.LEN);
     assert(existTokens_mem.top_unused+INIT_UNIQUE_TOKEN_SIZE <= existTokens_mem.LEN);
 
-    smry->token = &memToken[*pin_memToken];
+    smry->token = &token_hashmaps.ARRAY[token_hashmaps.top_unused];
     smry->existTokens = &existTokens_mem.ARRAY[existTokens_mem.top_unused];
 
-    *pin_memToken += hashMapsize;
+    token_hashmaps.top_unused += hashMapsize;
     existTokens_mem.top_unused += INIT_UNIQUE_TOKEN_SIZE;
 
     smry->nToken = 0;
@@ -71,12 +48,12 @@ void init_TxtSmry(TxtSmry* smry, TokenInfo* memToken, int* pin_memToken,int hash
     smry->isRealloc_existTokens = false;
 }
 
-void init_TxtSmry_arr(TxtSmry** smry, int len, TokenInfo* memToken, int hashMapsize){
+void init_TxtSmry_arr(TxtSmry** smry, int len, int hashmapSize){
     int pin_memToken = 0;
     *smry = (TxtSmry*)malloc(sizeof(TxtSmry)*len);
     assert(*smry !=NULL);
     for(int i=0;i<len;i++){
-        init_TxtSmry(&(*smry)[i], memToken, &pin_memToken, hashMapsize);
+        init_TxtSmry(&(*smry)[i], hashmapSize);
     }
 }
 

--- a/src/FindSimilar.h
+++ b/src/FindSimilar.h
@@ -40,7 +40,7 @@ typedef struct MEMORY {
     ULONG LEN;
 } MEMORY;
 
-static struct MEMORY loc_mem;
+static struct MEMORY token_hashmaps;
 static struct MEMORY existTokens_mem;
 
 
@@ -57,16 +57,11 @@ void kill_MEM(struct MEMORY* mem);
 
 
 /******Token and Structure*******/
-/** Token Information*/
-typedef struct TokenInfo{
-    int occur;
-    int* loc;//locations in string
-    bool isRealloc;
-} TokenInfo;
+
 
 /** Text Summary*/
 typedef struct TxtSmry{
-    TokenInfo* token; //len = Q_MODULE
+    int* token; //len = Q_MODULE
     int* existTokens; //Exist Token
     int nToken; // unique token number
     char* text; // Text
@@ -75,14 +70,10 @@ typedef struct TxtSmry{
 } TxtSmry;
 
 
-void init_TokenInfo(TokenInfo* tkf);
-void init_TokenInfo_arr(TokenInfo** tkf, ULONG len);
-void kill_TokenInfo_arr(TokenInfo* tkf);
-
 /** Intiate text summary*/
-void init_TxtSmry(TxtSmry* smry, TokenInfo* memToken, int* pin_memToken,int hashMapsize);
+void init_TxtSmry(TxtSmry* smry, int hashMapsize);
 /** Initiate array of text summary*/
-void init_TxtSmry_arr(TxtSmry** smry, int len, TokenInfo* memToken, int len_token_in_smry);
+void init_TxtSmry_arr(TxtSmry** smry, int len, int hashmapSize);
 /** Kill array of TxtSmry.*/
 void kill_TxtSmry_arr(TxtSmry* smry, int len);
 

--- a/test/test_FindSimilar.h
+++ b/test/test_FindSimilar.h
@@ -11,15 +11,15 @@ void memory_allocation_FS(void){
     int num_mail = 10;
     
     //Initiation
-    init_MEM(&loc_mem, num_mail*INIT_SPURIOUS_COUNT);
+    init_MEM(&token_hashmaps, num_mail*INIT_SPURIOUS_COUNT);
 
-    TEST_CHECK(loc_mem.LEN == num_mail*INIT_SPURIOUS_COUNT);
-    TEST_CHECK(loc_mem.top_unused == 0);
+    TEST_CHECK(token_hashmaps.LEN == num_mail*INIT_SPURIOUS_COUNT);
+    TEST_CHECK(token_hashmaps.top_unused == 0);
     
     //Garbage Collection
-    kill_MEM(&loc_mem);
-    TEST_CHECK(loc_mem.ARRAY == NULL);
-    TEST_CHECK(loc_mem.LEN == 0);
+    kill_MEM(&token_hashmaps);
+    TEST_CHECK(token_hashmaps.ARRAY == NULL);
+    TEST_CHECK(token_hashmaps.LEN == 0);
 }
 
 void test_init_FS(void){

--- a/test/test_FindSimilar.h
+++ b/test/test_FindSimilar.h
@@ -24,7 +24,7 @@ void memory_allocation_FS(void){
 
 void test_init_FS(void){
     TxtSmry* smrys;
-    int n_mails=100000;
+    int n_mails=1000;
     clock_t str;
     clock_t end;
 

--- a/test/test_FindSimilar.h
+++ b/test/test_FindSimilar.h
@@ -24,7 +24,7 @@ void memory_allocation_FS(void){
 
 void test_init_FS(void){
     TxtSmry* smrys;
-    int n_mails=10000;
+    int n_mails=100000;
     clock_t str;
     clock_t end;
 


### PR DESCRIPTION
Remove hash location in string
-------------------------------

- 這個更動省略了 每隔 hash 在 string 的位置
- 如果要找尋 spurious hit, 相同 hash 時, 就要重新讀文章, 得到 spurious hit 的段落


Disadvantage
-------------
- The information can not resolve the spurious hit in `Expression Matching` problem


