### PR TITLE
Find similar/fix datatype

### DIFF
--- a/src/FindSimilar.c
+++ b/src/FindSimilar.c
@@ -83,7 +83,7 @@ TxtSmry* Preprocess_FindSimilar(mail*  mails, int n_mails){
     Init_MEM_FindSimilar(&smrys, n_mails);
 
     for(int i=0;i<n_mails;i++){
-        summarize_content(&mails[i], &smrys[i]);
+        summarize_content(&smrys[i], &mails[i]);
     }
 
     return smrys;
@@ -95,7 +95,7 @@ void kill_FindSimilar(TxtSmry* smrys){
 }
 
 void summarize_content(TxtSmry* smry, mail* m){
-    summarize_hash(smry->text, smry);
+    summarize_hash(smry, smry->text);
     smry->id = m->id;
     smry->synced = true;
 }

--- a/src/FindSimilar.c
+++ b/src/FindSimilar.c
@@ -10,7 +10,7 @@ void init_MEM_ULONG(struct MEMORY_ULONG* mem, ULONG len){
 void init_MEM_SHORT(struct MEMORY_SHORT* mem, ULONG len){
     mem->LEN = len;
     //mem->ARRAY = (int*)malloc(mem->LEN*sizeof(int));
-    mem->ARRAY = (short*)calloc( mem->LEN, sizeof(short));
+    mem->ARRAY = (USHORT*)calloc( mem->LEN, sizeof(USHORT));
     assert(mem->ARRAY != NULL);
     mem->top_unused = 0;
 }

--- a/src/FindSimilar.h
+++ b/src/FindSimilar.h
@@ -25,7 +25,7 @@
 #define INIT_SPURIOUS_COUNT 10
 #define INIT_UNIQUE_TOKEN_SIZE 100
 #define ULONG unsigned long long
-
+#define USHORT unsigned short
 
 /**
  * @brief Information for global memory storage.
@@ -36,7 +36,7 @@
  */
 typedef struct MEMORY_SHORT {
     ULONG top_unused;
-    short* ARRAY;
+    USHORT* ARRAY;
     ULONG LEN;
 } MEMORY_SHORT;
 
@@ -70,7 +70,7 @@ void kill_MEM_SHORT(struct MEMORY_SHORT* mem);
 /** Text Summary*/
 typedef struct TxtSmry{
     int id;
-    short* token; //len = Q_MODULE
+    USHORT* token; //len = Q_MODULE
     ULONG* existTokens; //Exist Token
     int nToken; // unique token number
     char* text; // Text

--- a/src/FindSimilar.h
+++ b/src/FindSimilar.h
@@ -34,14 +34,20 @@
  * @param LOC_ARRAY array for store location data
  * @param LEN capacity of the memory
  */
-typedef struct MEMORY {
+typedef struct MEMORY_SHORT {
     ULONG top_unused;
-    int* ARRAY;
+    short* ARRAY;
     ULONG LEN;
-} MEMORY;
+} MEMORY_SHORT;
 
-static struct MEMORY token_hashmaps;
-static struct MEMORY existTokens_mem;
+typedef struct MEMORY_ULONG {
+    ULONG top_unused;
+    ULONG* ARRAY;
+    ULONG LEN;
+} MEMORY_ULONG;
+
+static struct MEMORY_SHORT token_hashmaps;
+static struct MEMORY_ULONG existTokens_mem;
 
 
 /**
@@ -50,10 +56,12 @@ static struct MEMORY existTokens_mem;
  * @param loc_mem global struct for memory storage
  * @param num_mail number of email
  */
-void init_MEM(struct MEMORY* mem, ULONG len);
+void init_MEM_ULONG(struct MEMORY_ULONG* mem, ULONG len);
+void init_MEM_SHORT(struct MEMORY_SHORT* mem, ULONG len);
 
 /** Recycle the memory of @ref LOC_MEM*/
-void kill_MEM(struct MEMORY* mem);
+void kill_MEM_ULONG(struct MEMORY_ULONG* mem);
+void kill_MEM_SHORT(struct MEMORY_SHORT* mem);
 
 
 /******Token and Structure*******/
@@ -61,8 +69,9 @@ void kill_MEM(struct MEMORY* mem);
 
 /** Text Summary*/
 typedef struct TxtSmry{
-    int* token; //len = Q_MODULE
-    int* existTokens; //Exist Token
+    int id;
+    short* token; //len = Q_MODULE
+    ULONG* existTokens; //Exist Token
     int nToken; // unique token number
     char* text; // Text
     bool synced; // Check the information is updated
@@ -77,10 +86,6 @@ void init_TxtSmry_arr(TxtSmry** smry, int len, int hashmapSize);
 /** Kill array of TxtSmry.*/
 void kill_TxtSmry_arr(TxtSmry* smry, int len);
 
-/**MAIN FUNCTION*/
-/**Initialte Memory for FindSimilar*/
-void Init_MEM_FindSimilar(TxtSmry**, int n_mails);
-void kill_MEM_FindSimilar(TxtSmry*);
 
 /******Hash*******/
 /** Get token hash
@@ -92,9 +97,28 @@ int popTokenHash(char message[], char token[], int iStr, int* Hash);
 int updateHash(char c, int Hash_cur, int q_cur, int d);
 
 /**********Main API************/
+
+/**Initialte Memory for FindSimilar*/
+void Init_MEM_FindSimilar(TxtSmry**, int n_mails);
+
 /** Preprocessing: Summarize the mails*/
 TxtSmry* Preprocess_FindSimilar(mail*  mails, int n_mails);
+
+/*GC for FindSimilar problem*/
 void kill_FindSimilar(TxtSmry* smrys);
+void kill_MEM_FindSimilar(TxtSmry*);
+
+/******************************/
+
+
+
+/*********Hash*********/
+void summarize_content(TxtSmry* smry, mail* m);
+void summarize_hash(TxtSmry* smry, char* text);
+
+
+
+/******Jaccob Similarity*****/
 
 /**
  * @brief Check the similarity of two messages is exceeding threshold.

--- a/test/test_FindSimilar.h
+++ b/test/test_FindSimilar.h
@@ -11,13 +11,13 @@ void memory_allocation_FS(void){
     int num_mail = 10;
     
     //Initiation
-    init_MEM(&token_hashmaps, num_mail*INIT_SPURIOUS_COUNT);
+    init_MEM_SHORT(&token_hashmaps, num_mail*INIT_SPURIOUS_COUNT);
 
     TEST_CHECK(token_hashmaps.LEN == num_mail*INIT_SPURIOUS_COUNT);
     TEST_CHECK(token_hashmaps.top_unused == 0);
     
     //Garbage Collection
-    kill_MEM(&token_hashmaps);
+    kill_MEM_SHORT(&token_hashmaps);
     TEST_CHECK(token_hashmaps.ARRAY == NULL);
     TEST_CHECK(token_hashmaps.LEN == 0);
 }
@@ -43,13 +43,11 @@ void test_init_FS(void){
 
 void test_init_content_FS(void){
     TxtSmry* smrys;
-    int n_mails=1000;
-
-
+    int n_mails=10000;
 
     Init_MEM_FindSimilar(&smrys, n_mails);
 
-
+    //Initial values
     for(int i=0;i<n_mails;i++){
         TEST_CHECK(smrys[i].nToken == 0);
         TEST_CHECK(smrys[i].isRealloc_existTokens == false);
@@ -59,12 +57,14 @@ void test_init_content_FS(void){
         TEST_CHECK(smrys[i].token[230] == 0);
     }
     
+    //The token array is 0 in default
     for(int i=0;i<Q_MODULO;i++){
         TEST_CHECK(smrys[n_mails-1].token[i]==0);
+        TEST_CHECK(smrys[234].token[i]==0);
+        TEST_CHECK(smrys[0].token[i]==0);
     }
 
     kill_MEM_FindSimilar(smrys);
-
 }
 
 


### PR DESCRIPTION
Save half of the space with `unsigned short`
-----------------------------------

> total heap usage: 5 allocs, 5 frees, 2,008,481,184 bytes allocated

Bug Fixed
----------

use `unsigned long long ` to store the location