### PR TITLE
bug fix: zero spurious hit

### DIFF
--- a/src/FindSimilar.c
+++ b/src/FindSimilar.c
@@ -122,6 +122,7 @@ void append_hash_TxtSmry(TxtSmry* smry, int hash){
         _add_unique_hashlist(smry, hash);
         ++smry->nToken;
     }
+    //Count is update here
     ++smry->token[hash].count;
 }
 
@@ -221,6 +222,12 @@ void summarize_hash(TxtSmry* smry, char* text){
             }
         }
 
+        //Append New Hash Until FULL
+        if(smry->token[hash].count<INIT_SPURIOUS_COUNT){
+            iloc = smry->token[hash].count;
+            smry->token[hash].loc[iloc] = iStr;
+        }
+
 
         //Append unique hash 
         if(smry->token[hash].count==0){//unique token
@@ -228,12 +235,6 @@ void summarize_hash(TxtSmry* smry, char* text){
             ++smry->nToken;
         }
 
-        //Append New Hash Until FULL
-        if(smry->token[hash].count<INIT_SPURIOUS_COUNT){
-            iloc = smry->token[hash].count;
-            smry->token[hash].loc[iloc] = iStr;
-        }
-        ++smry->token[hash].count;
 
         //Next token
         iStr = iNxt;


### PR DESCRIPTION
解決 spurious hit 一堆的問題:

這是個 error, 是因為重複使用

```
++smry->token[hash].count;
```

導致

注意
-----

```c
void append_hash_TxtSmry(TxtSmry* smry, int hash)
```
會執行

```
++smry->token[hash].count;
```

Result
-------
- 0 spurious hit
- 時間使用 5 秒是因為會去除 spurious hit
<img width="1155" alt="Screen Shot 2021-06-25 at 11 56 24 AM" src="https://user-images.githubusercontent.com/29009898/123367346-5e699100-d5ac-11eb-9f85-404a74fca203.png">
